### PR TITLE
Highlight regular expression blocks in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,20 @@ Perl, Ruby, and some other languages support a readable _extended_ regular expre
 
 For example, as far as Ruby is concerned,
 
-```
+```regexp
 /\d(?=(\d{3})+\b)/
 ```
 
 and
 
-```
-/ \d          # a digit
+```regexp
+/(?x)
+  \d          # a digit
   (?=         # followed by (look-ahead match)
     (\d{3})+  # one or more sets of three digits
     \b        # and then a word boundary
   )
-/x
+/
 ```
 
 are equivalent. For humans, however, the extended second version is obviously much easier to get to grips with.

--- a/README.source.md
+++ b/README.source.md
@@ -34,19 +34,20 @@ Perl, Ruby, and some other languages support a readable _extended_ regular expre
 
 For example, as far as Ruby is concerned,
 
-```
+```regexp
 /\d(?=(\d{3})+\b)/
 ```
 
 and
 
-```
-/ \d          # a digit
+```regexp
+/(?x)
+  \d          # a digit
   (?=         # followed by (look-ahead match)
     (\d{3})+  # one or more sets of three digits
     \b        # and then a word boundary
   )
-/x
+/
 ```
 
 are equivalent. For humans, however, the extended second version is obviously much easier to get to grips with.


### PR DESCRIPTION
This is a (really) trivial PR to add syntax highlighting to the regexp examples in the readme. The use of `(?x)` was required to enable `# comment` highlighting, which I only just noticed isn't showing up because of a [bug I fixed just now](https://github.com/Alhadis/language-regexp/commit/592b47f4ecf8793144e91601d5e9a41387914f87).

I, uh, swear the highlighting was more pronounced on GitHub when I last checked. Seems they updated their palette to use even duller colours... 😓  It should look like this:

<img src="https://user-images.githubusercontent.com/2346707/93267261-bc33a600-f7ee-11ea-8e4a-d9dae62b121a.png" alt="Figure 1" />

Not this:

<img src="https://user-images.githubusercontent.com/2346707/93267950-c4d8ac00-f7ef-11ea-919f-425ae10666e9.png" alt="Figure 2" />

Anywho, that's the gist of this craptastic enhancement. 😁